### PR TITLE
Release 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to charset-normalizer will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.1.3 (2025-03-06)
+
+### Fixed
+- Unstable cache key with no workaround to force it (see README to see how to apply `PLAYSMART_CACHE_PRESET` environment variable)
+- No retries if the LLM gave unparsable content
+
 ## 0.1.2 (2025-02-25)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ across your teams! Commit it!
 
 You may choose a filename at your own convenience via the `cache_path=...` parameter within the `Playsmart` class constructor.
 
+If your application does not have a stable content, you could be embarrassed by the ever invalidating cache.
+To remediate to this, set the following environment variable:
+
+```shell
+export PLAYSMART_CACHE_PRESET="example.com=v1.22"
+# or...
+export PLAYSMART_CACHE_PRESET="example.com=v1.22;example.org=v4.33"
+```
+
+This will actively prevent the cache to be invalidated.
+
 ### The 'want' method in a nutshell
 
 Basically, everything revolve around `Playsmart.want(...)` as you would have already guessed.

--- a/src/playsmart/_version.py
+++ b/src/playsmart/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
 version: str
-version = "0.1.2"
+version = "0.1.3"


### PR DESCRIPTION
## 0.1.3 (2025-03-06)

### Fixed
- Unstable cache key with no workaround to force it (see README to see how to apply `PLAYSMART_CACHE_PRESET` environment variable)
- No retries if the LLM gave unparsable content
